### PR TITLE
Hotfix: copy rules on init

### DIFF
--- a/dftparse/core.py
+++ b/dftparse/core.py
@@ -4,7 +4,9 @@ class BlockParser(object):
 
     def __init__(self, rules=[]):
         """Create a BlockParser, pre-loading a set of rules"""
-        self.rules = rules
+        self.rules = []
+        for rule in rules:
+            self.add_rule(rule)
 
     def add_rule(self, rule):
         """Add a rule to this parser"""

--- a/dftparse/tests/test_block_parser.py
+++ b/dftparse/tests/test_block_parser.py
@@ -1,0 +1,14 @@
+from dftparse.core import BlockParser
+
+
+def test_multiple_parsers():
+    """Test that parsers don't have interacting state"""
+    rules = []
+    first_parser = BlockParser(rules)
+    assert len(first_parser.rules) == 0
+
+    rules.append((lambda x: True, 1.0))
+    second_parser = BlockParser(rules)
+    assert len(second_parser.rules) == 1
+
+    assert len(first_parser.rules) == 0, "Non-local mutation of a parser's rules"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='dftparse',
-    version='0.2.0',
+    version='0.2.1',
     description='Library for parsing Density Functional Theory calculations',
     url='https://github.com/CitrineInformatics/dftparse',
     install_requires=[],


### PR DESCRIPTION
The parser's internal rule set was just pointed at the argument, which allowed funny non-local mutation of rules.  This makes a copy.