### PR TITLE
Parse unit cell volumes from OUTCAR

### DIFF
--- a/dftparse/vasp/outcar_parser.py
+++ b/dftparse/vasp/outcar_parser.py
@@ -9,8 +9,13 @@ def _parse_total_magnetization(line, lines):
         res["total magnetization"] = float(toks[5])
     return res
 
+def _parse_volume_of_cell(line, lines):
+    """Parse the volume of the unit cell"""
+    return {"volume of cell": float(line.split()[4])}
+
 base_rules = [
-    (lambda x: " number of electron " in x, _parse_total_magnetization)
+    (lambda x: " number of electron " in x, _parse_total_magnetization),
+    (lambda x: " volume of cell " in x, _parse_volume_of_cell)
 ]
 
 

--- a/dftparse/vasp/tests/test_outcar_parser.py
+++ b/dftparse/vasp/tests/test_outcar_parser.py
@@ -19,3 +19,16 @@ def test_parse_magnetization():
     res = _flatten(OutcarParser().parse(lines))
     assert res["total magnetization"] == -0.0000036, "Parsed the total magnetization incorrectly"
     assert res["number of electrons"] == 12.9999995, "Parsed the number of electrons incorrectly"
+
+
+def test_parse_volume_of_cell():
+    """Test that the volume of cell parses out correctly"""
+    lines = """
+ VOLUME and BASIS-vectors are now :
+ -----------------------------------------------------------------------------
+  energy-cutoff  :      650.00
+  volume of cell :       22.75
+      direct lattice vectors                 reciprocal lattice vectors
+    """.split("\n")
+    res = _flatten(OutcarParser().parse(lines))
+    assert res["volume of cell"] == 22.75, "Parsed the volume of cell incorrectly"


### PR DESCRIPTION
Adding rule to parse unit cell volume from VASP OUTCARs.

Long version (@maxhutch):
The `htdefects` package for high-throughput calculation of dilute-mixing/solubility uses `dfttopif.drivers.directory_to_pif` to parse the DFT output agnostic of the code used. Currently, the `pypif.pif.ChemicalSystem` object returned does not have a couple of properties (number of atoms in the unit cell, volumes) required by `htdefects.mixing`, so I'm adding those properties.
I'll submit a separate PR to `dfttopif` that adds the rest of the missing functionality/properties.