### PR TITLE
Remove python 3.4 testing and support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - '2.7'
-- '3.4'
 - '3.5'
 - '3.6'
 install:


### PR DESCRIPTION
We've moved our support lower bound up to 3.5 (for 3.x).